### PR TITLE
Added new method to check on which type the connection has

### DIFF
--- a/Swift-Reachability/Base.lproj/Main.storyboard
+++ b/Swift-Reachability/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6205" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6250" systemVersion="14A388a" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6198"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -31,16 +31,20 @@
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Connection Type: " lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AW6-RD-YHT">
+                                <rect key="frame" x="16" y="273" width="288" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                     <simulatedOrientationMetrics key="simulatedOrientationMetrics"/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4">
-                        <size key="portraitSize" width="320" height="568"/>
-                        <size key="landscapeSize" width="568" height="320"/>
-                    </simulatedScreenMetrics>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
                     <connections>
                         <outlet property="networkStatusLabel" destination="dLL-KO-YYV" id="eGb-em-3dE"/>
+                        <outlet property="networkTypeLabel" destination="AW6-RD-YHT" id="smr-TV-tg9"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>

--- a/Swift-Reachability/Reachability.swift
+++ b/Swift-Reachability/Reachability.swift
@@ -9,6 +9,12 @@
 import Foundation
 import SystemConfiguration
 
+enum ReachabilityType {
+    case WWAN,
+    WiFi,
+    NotConnected
+}
+
 public class Reachability {
     
     /**
@@ -33,6 +39,40 @@ public class Reachability {
         let needsConnection = (flags & UInt32(kSCNetworkFlagsConnectionRequired)) != 0
         
         return (isReachable && !needsConnection) ? true : false
+    }
+    
+    class func isConnectedToNetworkOfType() -> ReachabilityType {
+        
+        var zeroAddress = sockaddr_in(sin_len: 0, sin_family: 0, sin_port: 0, sin_addr: in_addr(s_addr: 0), sin_zero: (0, 0, 0, 0, 0, 0, 0, 0))
+        zeroAddress.sin_len = UInt8(sizeofValue(zeroAddress))
+        zeroAddress.sin_family = sa_family_t(AF_INET)
+        
+        
+        
+        let defaultRouteReachability = withUnsafePointer(&zeroAddress) {
+            SCNetworkReachabilityCreateWithAddress(nil, UnsafePointer($0)).takeRetainedValue()
+        }
+        
+        var flags: SCNetworkReachabilityFlags = 0
+        if SCNetworkReachabilityGetFlags(defaultRouteReachability, &flags) == 0 {
+            return .NotConnected
+        }
+        
+        let isReachable = (flags & UInt32(kSCNetworkFlagsReachable)) != 0
+        let isWWAN = (flags & UInt32(kSCNetworkReachabilityFlagsIsWWAN)) != 0
+        //let isWifI = (flags & UInt32(kSCNetworkReachabilityFlagsReachable)) != 0
+        
+        if(isReachable && isWWAN){
+            return .WWAN
+        }
+        if(isReachable && !isWWAN){
+            return .WiFi
+        }
+        
+        return .NotConnected
+        //let needsConnection = (flags & UInt32(kSCNetworkFlagsConnectionRequired)) != 0
+        
+        //return (isReachable && !needsConnection) ? true : false
     }
     
 }

--- a/Swift-Reachability/ViewController.swift
+++ b/Swift-Reachability/ViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 class ViewController: UIViewController {
 
     @IBOutlet var networkStatusLabel: UILabel!
+    @IBOutlet var networkTypeLabel: UILabel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -25,6 +26,23 @@ class ViewController: UIViewController {
             networkStatusLabel.text = "Internet Connection: Unavailable"
             networkStatusLabel.textColor = UIColor.redColor()
         }
+        
+        let statusType = Reachability.isConnectedToNetworkOfType()
+        switch statusType{
+        case .WWAN:
+            networkTypeLabel.text = "Connection Type: Mobile"
+            networkTypeLabel.textColor = UIColor.yellowColor()
+        case .WiFi:
+            networkTypeLabel.text = "Connection Type: WiFi"
+            networkTypeLabel.textColor = UIColor.greenColor()
+            
+        case .NotConnected:
+            networkTypeLabel.text = "Connection Type: Not connected to the Internet"
+            networkTypeLabel.textColor = UIColor.redColor()
+        }
+        
+        
+        
     }
     
 }


### PR DESCRIPTION
Sometimes you need to distinguish between Wifi and Mobile Connection.

I added the method
`isConnectedToNetworkOfType() -> ReachabilityType`
Which returns an enum value of the type:
`enum ReachabilityType {
   case WWAN,
    WiFi,
    NotConnected
}`

Also enhanced the example for it
