### PR TITLE
Make ReachabilityStatus Equatable

### DIFF
--- a/Reach-swift3.0/Reach.swift
+++ b/Reach-swift3.0/Reach.swift
@@ -39,7 +39,7 @@ enum ReachabilityType: CustomStringConvertible {
     }
 }
 
-enum ReachabilityStatus: CustomStringConvertible  {
+enum ReachabilityStatus: CustomStringConvertible, Equatable  {
     case offline
     case online(ReachabilityType)
     case unknown
@@ -50,6 +50,11 @@ enum ReachabilityStatus: CustomStringConvertible  {
         case .online(let type): return "Online (\(type))"
         case .unknown: return "Unknown"
         }
+    }
+
+    static func ==(lhs: ReachabilityStatus, rhs: ReachabilityStatus) -> Bool
+    {
+        return lhs.description == rhs.description
     }
 }
 


### PR DESCRIPTION
I was unable to compare is returned status is a particular one - I would get an error like this
<img width="989" alt="screen shot 2016-11-29 at 09 02 18" src="https://cloud.githubusercontent.com/assets/392168/20699929/bdd07da2-b612-11e6-92b5-c7a88debe026.png">
So I've added mysqlf an Equatable protocol and its implementation to ReachabilityStatus