### PR TITLE
Add shorthand method to check if status is one of .online

### DIFF
--- a/Reach-swift3.0/Reach.swift
+++ b/Reach-swift3.0/Reach.swift
@@ -51,6 +51,16 @@ enum ReachabilityStatus: CustomStringConvertible  {
         case .unknown: return "Unknown"
         }
     }
+
+    func isOnline() -> Bool {
+        switch self {
+            case .online(.wwan), .online(.wiFi):
+                return true;
+
+            default:
+                return false;
+        }
+    }
 }
 
 public class Reach {


### PR DESCRIPTION
I think it is a frequent case where it is sufficient to know if you are online at all without caring for the connection type, so I've added a helper method for the ReachabilityStatus to tell if its one of the `.online` options